### PR TITLE
fix an exception which happens while using unicode characters as delimiter

### DIFF
--- a/rbql/csv_utils.py
+++ b/rbql/csv_utils.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 import re
-
+import sys
 
 newline_rgx = re.compile('(?:\r\n)|\r|\n')
 
@@ -102,3 +102,7 @@ def unquote_fields(fields):
     return [unquote_field(f) for f in fields]
 
 
+def ensure_unicode(text):
+    if sys.version_info[0] >= 3:
+        return text
+    return text.decode("utf-8")

--- a/rbql/rbql_csv.py
+++ b/rbql/rbql_csv.py
@@ -33,11 +33,14 @@ def read_user_init_code(rbql_init_source_path):
         return src.read()
 
 
-def normalize_delim(delim):
+def normalize_delim(delim, encoding):
     if delim == 'TAB':
         return '\t'
     if delim == r'\t':
         return '\t'
+
+    if encoding == 'utf-8':
+        return csv_utils.ensure_unicode(delim)
     return delim
 
 

--- a/rbql/rbql_main.py
+++ b/rbql/rbql_main.py
@@ -53,7 +53,7 @@ def show_warning(msg, is_interactive):
 
 
 def run_with_python(args, is_interactive):
-    delim = rbql_csv.normalize_delim(args.delim)
+    delim = rbql_csv.normalize_delim(args.delim, args.encoding)
     policy = args.policy if args.policy is not None else get_default_policy(delim)
     query = args.query
     input_path = args.input
@@ -191,7 +191,7 @@ def start_preview_mode(args):
         show_error('generic', 'Input file must be provided in interactive mode. You can use stdin input only in non-interactive mode', is_interactive=True)
         return
     if args.delim is not None:
-        delim = rbql_csv.normalize_delim(args.delim)
+        delim = rbql_csv.normalize_delim(args.delim, args.encoding)
         policy = args.policy if args.policy is not None else get_default_policy(delim)
     else:
         delim, policy = autodetect_delim_policy(input_path, args.encoding)

--- a/test/test_csv_utils.py
+++ b/test/test_csv_utils.py
@@ -321,6 +321,25 @@ class TestSplitMethods(unittest.TestCase):
                 self.assertEqual(expected_fields, test_fields)
 
 
+    def test_ensure_unicode(self):
+        test_cases = list()
+        test_cases.append((',', ','))
+        test_cases.append((' ', ' '))
+        test_cases.append(('\t', '\t'))
+        if PY3:
+            test_cases.append(('\u2063', u'\u2063'))
+        else:  # PY2 by default makes all strings 'str', following byte-array is equivalent of '\u2063'
+            test_cases.append((str(bytearray([226, 129, 163])), u'\u2063'))
+
+        for tc in test_cases:
+            src, expected = tc
+            test_dst = csv_utils.ensure_unicode(src)
+            self.assertEqual(expected, test_dst)
+            if PY3:  # in PY3, By default all strings are in 'str' type and unicode
+                self.assertEqual(str, type(test_dst))
+            else:  # In PY2 unicode strings in 'unicode' type
+                self.assertEqual(unicode, type(test_dst))
+
 
 class TestLineSplit(unittest.TestCase):
     def test_split_lines_custom(self):


### PR DESCRIPTION
When using unicode delimiters following exception happens. This PR addresses this issue.

```bash
➜  ~ rbql-py --delim $(echo "\u2063") --encoding utf-8 --policy simple --query "select top 10 a1" --input /<path-to>/test-out.csv.txt 
/usr/local/lib/python2.7/site-packages/rbql/rbql_csv.py:37: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if delim == 'TAB':
/usr/local/lib/python2.7/site-packages/rbql/rbql_csv.py:39: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if delim == r'\t':
/usr/local/lib/python2.7/site-packages/rbql/rbql_csv.py:382: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if input_delim == '"' and input_policy == 'quoted':
/usr/local/lib/python2.7/site-packages/rbql/rbql_csv.py:384: UnicodeWarning: Unicode unequal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if input_delim != ' ' and input_policy == 'whitespace':
Error [unexpected]: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)
```
(this file contains an invisible character as a seperator, \u2063)
[test-out.csv.txt](https://github.com/mechatroner/RBQL/files/3464100/test-out.csv.txt)
